### PR TITLE
chore: Updated workflow to decode Base64 encoded secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ This GitHub Action automates the process of building and publishing Android appl
 
 ## Inputs
 
-| Input                  | Description                            | Required |
-|------------------------|----------------------------------------|----------|
-| `release_type`         | Type of release (internal/beta)        | Yes      |
-| `android_package_name` | Name of the Android project module     | Yes      |
-| `keystore_file`        | Base64 encoded keystore file           | Yes      |
-| `keystore_password`    | Password for the keystore file         | Yes      |
-| `key_alias`            | Key alias for the keystore file        | Yes      |
-| `key_password`         | Password for the key alias             | Yes      |
-| `google_services`      | Google services JSON file content      | Yes      |
-| `playstore_creds`      | Firebase credentials JSON file content | Yes      |
+| Input                  | Description                                           | Required |
+|------------------------|-------------------------------------------------------|----------|
+| `release_type`         | Type of release (internal/beta)                       | Yes      |
+| `android_package_name` | Name of the Android project module                    | Yes      |
+| `keystore_file`        | Base64 encoded keystore file                          | Yes      |
+| `keystore_password`    | Password for the keystore file                        | Yes      |
+| `key_alias`            | Key alias for the keystore file                       | Yes      |
+| `key_password`         | Password for the key alias                            | Yes      |
+| `google_services`      | Base64 encoded Google services JSON file content      | Yes      |
+| `playstore_creds`      | Base64 encoded Firebase credentials JSON file content | Yes      |
 
 ## Usage
 

--- a/action.yaml
+++ b/action.yaml
@@ -2,8 +2,8 @@ name: 'KMP Publish Android App to Play Store Beta'
 description: 'Publish the Android app to the Play Store Beta or Internal Track'
 author: 'Mifos Initiative'
 branding:
-  icon: 'upload-cloud'
-  color: 'yellow'
+  icon: 'upload'
+  color: 'orange'
 
 inputs:
   release_type:
@@ -96,11 +96,11 @@ runs:
         echo $KEYSTORE | base64 --decode > ${{ inputs.android_package_name }}/release_keystore.keystore
         
         # Inflate google-services.json
-        echo $GOOGLE_SERVICES > ${{ inputs.android_package_name }}/google-services.json
+        echo $GOOGLE_SERVICES | base64 --decode > ${{ inputs.android_package_name }}/google-services.json
         
         # Inflate PlayStore credentials
         touch ${{ inputs.android_package_name }}/playStorePublishServiceCredentialsFile.json
-        echo $PLAYSTORE_CREDS > ${{ inputs.android_package_name }}/playStorePublishServiceCredentialsFile.json
+        echo $PLAYSTORE_CREDS | base64 --decode > ${{ inputs.android_package_name }}/playStorePublishServiceCredentialsFile.json
 
     # Build Android App Bundle for Play Store
     - name: Build Release


### PR DESCRIPTION
This commit updates the workflow to decode Base64 encoded secrets for keystore, google-services.json, and playStorePublishServiceCredentialsFile.json.

Additionally, the commit changes the action icon to "upload" and the color to "orange". The input description for `google_services` and `playstore_creds` has been updated to reflect the Base64 encoding.