### PR TITLE
refactor: Renamed fastlane lane and updated workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ platform :android do
   end
 
   desc "Deploy to Internal Testing Track"
-  lane :deploy_internal do
+  lane :deployInternal do
     upload_to_play_store(
       track: 'internal',
       aab: lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH],
@@ -150,4 +150,4 @@ base64 -i path/to/play-store-credentials.json -o playstore-creds.txt
 
 ## Artifacts
 
-The action saves the generated AAB files as artifacts with the name 'release-aabs'. You can find these in your GitHub Actions run.
+The action saves the generated AAB files as artifacts with the name 'playstore-aabs'. You can find these in your GitHub Actions run.

--- a/action.yaml
+++ b/action.yaml
@@ -71,33 +71,29 @@ runs:
         touch secrets/playStorePublishServiceCredentialsFile.json
         echo $PLAYSTORE_CREDS | base64 --decode > secrets/playStorePublishServiceCredentialsFile.json
 
-    - name: Bundle Android App
+    # Deploy to Play Store Internal testing track
+    - name: Deploy to Playstore Internal
       shell: bash
       env:
         KEYSTORE_PASSWORD: ${{ inputs.keystore_password }}
         KEYSTORE_ALIAS: ${{ inputs.keystore_alias }}
         KEYSTORE_ALIAS_PASSWORD: ${{ inputs.keystore_alias_password }}
       run: |
-        bundle exec fastlane android bundlePlayStoreRelease \
+        bundle exec fastlane android deployInternal \
         storeFile:release_keystore.keystore \
         storePassword:${{ env.KEYSTORE_PASSWORD }} \
         keyAlias:${{ env.KEYSTORE_ALIAS }} \
         keyPassword:${{ env.KEYSTORE_ALIAS_PASSWORD }}
-
-    # Save AAB files as artifacts
-    - name: Archive Build
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-aabs
-        path: ./**/*.aab
-
-    # Deploy to Play Store Internal testing track
-    - name: Deploy to Playstore Internal
-      shell: bash
-      run: bundle exec fastlane android deploy_internal
 
     # Promote to beta if specified
     - name: Promote Internal to Beta
       shell: bash
       if: inputs.release_type == 'beta'
       run: bundle exec fastlane android promote_to_beta
+
+    # Save AAB files as artifacts
+    - name: Archive Build
+      uses: actions/upload-artifact@v4
+      with:
+        name: playstore-aabs
+        path: ./**/*.aab


### PR DESCRIPTION
This commit refactors the fastlane lane for deploying to internal testing from `deploy_internal` to `deployInternal`. It also updates the workflow to:

- Deploy to the Play Store's internal testing track using the new `deployInternal` lane.
- Rename the artifact name for the saved AAB files from `release-aabs` to `playstore-aabs`.
- Combine the build and deployment to internal testing steps into a single step.
- Conditionally promote the release to beta using the `promote_to_beta` lane, based on the `release_type` input.