### PR TITLE
fix: Fixed typo in promote to beta lane

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -89,7 +89,7 @@ runs:
     - name: Promote Internal to Beta
       shell: bash
       if: inputs.release_type == 'beta'
-      run: bundle exec fastlane android promote_to_beta
+      run: bundle exec fastlane android promoteToBeta
 
     # Save AAB files as artifacts
     - name: Archive Build


### PR DESCRIPTION
This commit fixes a typo in the `promote_to_beta` lane, changing it to `promoteToBeta` to correctly trigger the promotion action.